### PR TITLE
HID: ft260: (partially) fix "HID: ft260: ft260_i2c_read cleanup"

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -529,25 +529,20 @@ static int ft260_i2c_read(struct ft260_device *dev, u8 addr, u8 *data,
 	}
 
 	do {
-		if (FT260_FLAG_START_REPEATED ==
-			(FT260_FLAG_START_REPEATED & flag))
-			flag = FT260_FLAG_START_REPEATED;
-		else
-			flag = FT260_FLAG_START;
+		rep.flag = flag & FT260_FLAG_START_REPEATED;
 
 		if (len <= FT260_RD_DATA_MAX) {
 			rd_len = len;
-			flag |= FT260_FLAG_STOP;
+			rep.flag |= FT260_FLAG_STOP;
 		} else {
 			rd_len = FT260_RD_DATA_MAX;
 		}
 
 		rep.length = cpu_to_le16(rd_len);
 		rep.address = addr;
-		rep.flag = flag;
 
 		ft260_dbg("2 rep %#02x addr %#02x len %d rlen %d flag %#x\n",
-			  rep.report, rep.address, len, rd_len, flag);
+			  rep.report, rep.address, len, rd_len, rep.flag);
 
 		reinit_completion(&dev->wait);
 


### PR DESCRIPTION
Unfortunately, after the "HID: ft260: ft260_i2c_read cleanup" commit "long" reads did not work anymore.

Generated flag sequence for a 608 bytes read request before this change:

```
[  +0,000581] ft260_i2c_read: 1 rep 0xc5 addr 0x10 len 608 rlen 60 flag 0x6 
[  +0,007910] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,000222] ft260_xfer_status: bus_status 0x20, clock 100 
[  +0,000003] ft260_i2c_read: 2 rep 0xc2 addr 0x10 len 548 rlen 256 flag 0x2 
[  +0,007777] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,007013] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,005970] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,006015] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,001967] ft260_raw_event: i2c resp: rep 0xd3 len 16 
[  +0,000197] ft260_xfer_status: bus_status 0x40, clock 100 
[  +0,000004] ft260_i2c_read: 2 rep 0xc2 addr 0x10 len 292 rlen 256 flag 0x2 
[  +0,001824] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,001007] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,000999] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,001015] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,000964] ft260_raw_event: i2c resp: rep 0xd3 len 16 
[  +0,000240] ft260_xfer_status: bus_status 0x60, clock 100 
[  +0,000004] ft260_i2c_read: 2 rep 0xc2 addr 0x10 len 36 rlen 36 flag 0x6 
[  +0,001752] ft260_raw_event: i2c resp: rep 0xd8 len 36 
[  +0,000193] ft260_xfer_status: bus_status 0x72, clock 100 
[  +0,000006] ft260 0003:0403:6030.0034: i2c bus error: 0x72 
[  +0,000182] ft260_i2c_reset: done
```

Generated flag sequence for a 608 bytes read request after this change:

```
[  +0,000601] ft260_i2c_read: 1 rep 0xdc addr 0x10 len 608 rlen 60 flag 0x6 
[  +0,007898] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,000204] ft260_xfer_status: bus_status 0x20, clock 100 
[  +0,000004] ft260_i2c_read: 2 rep 0xc2 addr 0x10 len 548 rlen 256 flag 0x2 
[  +0,007723] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,006962] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,005989] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,006030] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,001971] ft260_raw_event: i2c resp: rep 0xd3 len 16 
[  +0,000299] ft260_xfer_status: bus_status 0x40, clock 100 
[  +0,000004] ft260_i2c_read: 2 rep 0xc2 addr 0x10 len 292 rlen 256 flag 0x0 
[  +0,007768] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,005999] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,006999] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,006041] ft260_raw_event: i2c resp: rep 0xde len 60 
[  +0,001931] ft260_raw_event: i2c resp: rep 0xd3 len 16 
[  +0,000253] ft260_xfer_status: bus_status 0x40, clock 100 
[  +0,000005] ft260_i2c_read: 2 rep 0xc2 addr 0x10 len 36 rlen 36 flag 0x4 
[  +0,004752] ft260_raw_event: i2c resp: rep 0xd8 len 36 
[  +0,000313] ft260_xfer_status: bus_status 0x20, clock 100
```

(Looks same as with "HID: FT260: missed NACK on big i2c reads".)

Even with this fix, calling ft260_i2c_read() will not work as expected if called with FT260_FLAG_START_REPEATED, as the first 60 bytes read uses FT260_FLAG_START_STOP.