### PR TITLE
Add gpio support

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -13,6 +13,7 @@
 #include <linux/i2c.h>
 #include <linux/module.h>
 #include <linux/usb.h>
+#include <linux/gpio/driver.h>
 
 #ifdef DEBUG
 static int ft260_debug = 1;
@@ -29,7 +30,7 @@ MODULE_PARM_DESC(debug, "Toggle FT260 debugging messages");
 	} while (0)
 
 #define FT260_REPORT_MAX_LENGTH (64)
-#define FT260_I2C_DATA_REPORT_ID(len) (FT260_I2C_REPORT_MIN + (len - 1) / 4)
+#define FT260_I2C_DATA_REPORT_ID(len) (FT260_I2C_REPORT_MIN + ((len) - 1) / 4)
 
 #define FT260_WAKEUP_NEEDED_AFTER_MS (4800) /* 5s minus 200ms margin */
 
@@ -46,6 +47,11 @@ MODULE_PARM_DESC(debug, "Toggle FT260 debugging messages");
 */
 #define FT260_RD_DATA_MAX (180)
 #define FT260_WR_DATA_MAX (60)
+
+#define FT260_GPIOCHIP "ft260_gpio"
+#define FT260_GPIO_MAX (6)
+#define FT260_GPIO_EX_MAX (8)
+#define FT260_GPIO_TOTAL (FT260_GPIO_MAX + FT260_GPIO_EX_MAX)
 
 /*
  * Device interface configuration.
@@ -132,7 +138,50 @@ enum {
 	FT260_FLAG_START_STOP_REPEATED	= 0x07,
 };
 
-#define FT260_SET_REQUEST_VALUE(report_id) ((FT260_FEATURE << 8) | report_id)
+/* Multi-function pin functions */
+enum {
+	FT260_MFPIN_GPIO		= 0x00,
+	FT260_MFPIN_SUSPOUT		= 0x01,
+	FT260_MFPIN_PWREN		= 0x02,
+	FT260_MFPIN_TX_ACTIVE		= 0x03,
+	FT260_MFPIN_TX_LED		= 0x04,
+	FT260_MFPIN_RX_LED		= 0x05,
+	FT260_MFPIN_BCD_DET		= 0x06,
+};
+
+enum {
+	FT260_GPIO_VALUE		= 0x00,
+	FT260_GPIO_DIRECTION		= 0x01,
+	FT260_GPIO_DIR_INPUT		= 0x00,
+	FT260_GPIO_DIR_OUTPUT		= 0x01,
+};
+
+/* GPIO offsets */
+enum {
+	FT260_GPIO_0			= (1 << 0),
+	FT260_GPIO_1			= (1 << 1),
+	FT260_GPIO_2			= (1 << 2),
+	FT260_GPIO_3			= (1 << 3),
+	FT260_GPIO_4			= (1 << 4),
+	FT260_GPIO_5			= (1 << 5),
+	FT260_GPIO_A			= (1 << (FT260_GPIO_MAX + 0)),
+	FT260_GPIO_B			= (1 << (FT260_GPIO_MAX + 1)),
+	FT260_GPIO_C			= (1 << (FT260_GPIO_MAX + 2)),
+	FT260_GPIO_D			= (1 << (FT260_GPIO_MAX + 3)),
+	FT260_GPIO_E			= (1 << (FT260_GPIO_MAX + 4)),
+	FT260_GPIO_F			= (1 << (FT260_GPIO_MAX + 5)),
+	FT260_GPIO_G			= (1 << (FT260_GPIO_MAX + 6)),
+	FT260_GPIO_H			= (1 << (FT260_GPIO_MAX + 7)),
+	FT260_GPIO_WAKEUP		= (FT260_GPIO_3),
+	FT260_GPIO_I2C			= (FT260_GPIO_0 | FT260_GPIO_1 ),
+	FT260_GPIO_UART_DCD_RI		= (FT260_GPIO_4 | FT260_GPIO_5 ),
+	FT260_GPIO_UART			= (FT260_GPIO_B | FT260_GPIO_E |
+					   FT260_GPIO_F | FT260_GPIO_H ),
+	FT260_GPIO_DEFAULT		= (FT260_GPIO_UART |
+					   FT260_GPIO_UART_DCD_RI),
+};
+
+#define FT260_SET_REQUEST_VALUE(report_id) ((FT260_FEATURE << 8) | (report_id))
 
 /* Feature In reports */
 
@@ -171,6 +220,18 @@ struct ft260_get_i2c_status_report {
 	u8 reserved;
 } __packed;
 
+struct ft260_gpio_state {
+	u8 vals;		/* GPIO[0-5] values in bits 0 - 5 */
+	u8 dirs;		/* GPIO[0-5] directions, 0 - in, 1 - out */
+	u8 ex_vals;		/* GPIO[A-H] values in bits 0 - 7 */
+	u8 ex_dirs;		/* GPIO[A-H] directions, 0 - in, 1 - out */
+} __packed;
+
+struct ft260_gpio_read_request_report {
+	u8 report;		/* FT260_GPIO */
+	struct ft260_gpio_state	gpio;
+} __packed;
+
 /* Feature Out reports */
 
 struct ft260_set_system_clock_report {
@@ -201,6 +262,33 @@ struct ft260_set_i2c_speed_report {
 	u8 report;		/* FT260_SYSTEM_SETTINGS */
 	u8 request;		/* FT260_SET_I2C_CLOCK_SPEED */
 	__le16 clock;		/* I2C bus clock in range 60-3400 KHz */
+} __packed;
+
+struct ft260_set_gpio2_fun_report {
+	u8 report;		/* FT260_SYSTEM_SETTINGS */
+	u8 request;		/* FT260_SELECT_GPIO2_FUNC */
+	u8 function;		/* Pin func: 0 - GPIO, 1 - SUSPOUT, */
+				/* 2 - PWREN# (active-low), 4 - TX_LED */
+} __packed;
+
+struct ft260_set_gpioa_fun_report {
+	u8 report;		/* FT260_SYSTEM_SETTINGS */
+	u8 request;		/* FT260_SELECT_GPIOA_FUNC */
+	u8 function;		/* Pin func: 0 - GPIO, */
+				/* 3 - TX_ACTIVE, 4 - TX_LED */
+} __packed;
+
+struct ft260_set_gpiog_fun_report {
+	u8 report;		/* FT260_SYSTEM_SETTINGS */
+	u8 request;		/* FT260_SELECT_GPIOG_FUNC */
+	u8 function;		/* Pin func: 0 - GPIO, */
+				/* 2 - PWREN# (active-low), */
+				/* 5 - RX_LED, 6 - BCD_DET */
+} __packed;
+
+struct ft260_gpio_write_request_report {
+	u8 report;		/* FT260_GPIO */
+	struct ft260_gpio_state	gpio;
 } __packed;
 
 /* Data transfer reports */
@@ -237,13 +325,17 @@ struct ft260_device {
 	struct i2c_adapter adap;
 	struct hid_device *hdev;
 	struct completion wait;
+	struct gpio_chip *gc;
 	struct mutex lock;
 	u8 write_buf[FT260_REPORT_MAX_LENGTH];
+	u8 feature_buf[FT260_REPORT_MAX_LENGTH];
 	unsigned long need_wakeup_at;
 	u8 *read_buf;
 	u16 read_idx;
 	u16 read_len;
 	u16 clock;
+	struct ft260_gpio_state gpio;
+	u16 gpio_en;
 };
 
 static int ft260_hid_feature_report_get(struct hid_device *hdev,
@@ -277,8 +369,6 @@ static int ft260_hid_feature_report_set(struct hid_device *hdev, u8 *data,
 	if (!buf)
 		return -ENOMEM;
 
-	buf[0] = FT260_SYSTEM_SETTINGS;
-
 	ret = hid_hw_raw_request(hdev, buf[0], buf, len, HID_FEATURE_REPORT,
 				 HID_REQ_SET_REPORT);
 
@@ -291,6 +381,7 @@ static int ft260_i2c_reset(struct hid_device *hdev)
 	struct ft260_set_i2c_reset_report report;
 	int ret;
 
+	report.report = FT260_SYSTEM_SETTINGS;
 	report.request = FT260_SET_I2C_RESET;
 
 	ret = ft260_hid_feature_report_set(hdev, (u8 *)&report, sizeof(report));
@@ -767,6 +858,206 @@ static const struct i2c_algorithm ft260_i2c_algo = {
 	.functionality = ft260_functionality,
 };
 
+static int ft260_gpio_chip_match_name(struct gpio_chip *chip, void *data)
+{
+	return !strcmp(chip->label, data);
+}
+
+/*
+ * For GPIO, we use hid_hw_raw_request directly with preallocated buffer to not
+ * interfere with i2c operation.
+ * TODO: Consider adding gpio_lock.
+ * TODO: consider replacing ft260_gpio_read_request_report and
+ * ft260_gpio_write_request_report with a single ft260_gpio_request_report.
+ */
+static void ft260_gpio_set(struct gpio_chip *gc, u32 offset, int value)
+{
+	int ret;
+	struct ft260_gpio_write_request_report *rep;
+	int len = sizeof(struct ft260_gpio_read_request_report);
+	struct ft260_device *dev = gpiochip_get_data(gc);
+	struct hid_device *hdev = dev->hdev;
+
+	if (!(dev->gpio_en & (1 << offset))) {
+		hid_err(hdev, "%s: wrong pin function %d\n", __func__, offset);
+		return;
+	}
+
+	if (offset >= FT260_GPIO_TOTAL) {
+		hid_err(hdev, "%s: invalid offset %d\n", __func__, offset);
+		return;
+	}
+
+	ft260_dbg("offset %d val %d\n", offset, value);
+
+	mutex_lock(&dev->lock);
+
+	rep = (struct ft260_gpio_write_request_report *)&dev->feature_buf;
+
+	rep->gpio = dev->gpio;
+
+	if ( offset < FT260_GPIO_MAX) {
+		if (value)
+			rep->gpio.vals |= !!value << offset;
+		else
+			rep->gpio.vals &= ~(1 << offset);
+	} else {
+		offset = offset - FT260_GPIO_MAX;
+		if (value)
+			rep->gpio.ex_vals |= !!value << offset;
+		else
+			rep->gpio.ex_vals &= ~(1 << offset);
+	}
+
+	ft260_dbg("dirs %#02x vals %#02x ex_dir %#02x ex_vals %#02x\n",
+		  rep->gpio.dirs, rep->gpio.vals,
+		  rep->gpio.ex_dirs, rep->gpio.ex_vals);
+
+	ret = hid_hw_raw_request(hdev, FT260_GPIO, (u8 *)rep, len,
+				 HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
+	if (ret < 0) {
+		hid_err(hdev, "%s: error setting GPIO: %d\n", __func__, ret);
+		mutex_unlock(&dev->lock);
+		return;
+	}
+
+	dev->gpio = rep->gpio;
+	mutex_unlock(&dev->lock);
+}
+
+static int ft260_gpio_direction_set(struct gpio_chip *gc, u32 offset,
+				    int value, int direction)
+{
+	int ret;
+	u8 *buf;
+	struct ft260_gpio_write_request_report *rep;
+	int len = sizeof(struct ft260_gpio_read_request_report);
+	struct ft260_device *dev = gpiochip_get_data(gc);
+	struct hid_device *hdev = dev->hdev;
+
+	if (!(dev->gpio_en & (1 << offset))) {
+		hid_err(hdev, "%s: wrong pin function %d\n", __func__, offset);
+		return -EIO;
+	}
+
+	if (offset >= FT260_GPIO_TOTAL) {
+		hid_err(hdev, "%s: invalid offset %d\n", __func__, offset);
+		return -EINVAL;
+	}
+
+	ft260_dbg("offset %d val %d direction %d\n", offset, value, direction);
+
+	buf = (u8 *)&dev->feature_buf;
+
+	mutex_lock(&dev->lock);
+	ret = hid_hw_raw_request(hdev, FT260_GPIO, buf, len,
+				 HID_FEATURE_REPORT, HID_REQ_GET_REPORT);
+	if (ret != len) {
+		ret = ret < 0 ? ret : -EIO;
+		hid_err(hdev, "%s: error getting GPIO: %d\n", __func__, ret);
+		goto exit;
+	}
+
+	rep = (struct ft260_gpio_write_request_report *)buf;
+	len = sizeof(struct ft260_gpio_write_request_report);
+
+	if (direction == FT260_GPIO_DIR_OUTPUT)
+		if ( offset < FT260_GPIO_MAX)
+			rep->gpio.dirs |= 1 << offset;
+		else
+			rep->gpio.ex_dirs |= 1 << (offset - FT260_GPIO_MAX);
+	else
+		if ( offset < FT260_GPIO_MAX)
+			rep->gpio.dirs &= ~(1 << offset);
+		else
+			rep->gpio.ex_dirs &= ~(1 << (offset - FT260_GPIO_MAX));
+
+	ft260_dbg("dirs %#02x val %#02x ex_dirs %#02x ex_vals %#02x\n",
+		  rep->gpio.dirs, rep->gpio.vals,
+		  rep->gpio.ex_dirs, rep->gpio.ex_vals);
+
+	ret = hid_hw_raw_request(hdev, FT260_GPIO, buf, len,
+				 HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
+
+	if (ret < 0) {
+		hid_err(hdev, "%s: error setting GPIO: %d\n", __func__, ret);
+		goto exit;
+	}
+
+	dev->gpio = rep->gpio;
+	mutex_unlock(&dev->lock);
+
+	if (direction == FT260_GPIO_DIR_OUTPUT)
+		ft260_gpio_set(gc, offset, value);
+
+	return 0;
+exit:
+	mutex_unlock(&dev->lock);
+	return ret;
+}
+
+static int ft260_gpio_direction_output(struct gpio_chip *gc,
+				       u32 offset, int value)
+{
+	return ft260_gpio_direction_set(gc, offset, value,
+					FT260_GPIO_DIR_OUTPUT);
+}
+
+static int ft260_gpio_direction_input(struct gpio_chip *gc, u32 offset)
+{
+	return ft260_gpio_direction_set(gc, offset, 0,
+					FT260_GPIO_DIR_INPUT);
+}
+
+static int ft260_gpio_get_all(struct gpio_chip *gc, int item)
+{
+	int ret;
+	u8 *buf;
+	struct ft260_gpio_read_request_report *rep;
+	int len = sizeof(struct ft260_gpio_read_request_report);
+	struct ft260_device *dev = gpiochip_get_data(gc);
+	struct hid_device *hdev = dev->hdev;
+
+	buf = (u8 *)&dev->feature_buf;
+
+	mutex_lock(&dev->lock);
+	ret = hid_hw_raw_request(hdev, FT260_GPIO, buf, len,
+				 HID_FEATURE_REPORT, HID_REQ_GET_REPORT);
+
+	if (ret != len) {
+		ret = ret < 0 ? ret : -EIO;
+		hid_err(hdev, "%s: error getting GPIO: %d\n", __func__, ret);
+		goto exit;
+	}
+
+	rep = (struct ft260_gpio_read_request_report *)buf;
+	if (item == FT260_GPIO_VALUE)
+		ret = (rep->gpio.ex_vals << FT260_GPIO_MAX) |
+		       rep->gpio.vals;
+	else
+		ret = (rep->gpio.ex_dirs << FT260_GPIO_MAX) |
+		       rep->gpio.dirs;
+exit:
+	mutex_unlock(&dev->lock);
+	return ret;
+}
+
+static int ft260_gpio_get_direction(struct gpio_chip *gc, u32 offset)
+{
+	int ret = ft260_gpio_get_all(gc, FT260_GPIO_DIRECTION);
+	if (ret < 0)
+		return ret;
+	return (ret >> offset) & 1;
+}
+
+static int ft260_gpio_get(struct gpio_chip *gc, u32 offset)
+{
+	int ret = ft260_gpio_get_all(gc, FT260_GPIO_VALUE);
+	if (ret < 0)
+		return ret;
+	return (ret >> offset) & 1;
+}
+
 static int ft260_get_system_config(struct hid_device *hdev,
 				   struct ft260_get_system_status_report *cfg)
 {
@@ -798,6 +1089,10 @@ static int ft260_is_interface_enabled(struct hid_device *hdev)
 	ft260_dbg("clock_ctl:  0x%02x\n", cfg.clock_ctl);
 	ft260_dbg("i2c_enable: 0x%02x\n", cfg.i2c_enable);
 	ft260_dbg("uart_mode:  0x%02x\n", cfg.uart_mode);
+	ft260_dbg("gpio2_func: 0x%02x\n", cfg.gpio2_function);
+	ft260_dbg("gpioA_func: 0x%02x\n", cfg.gpioA_function);
+	ft260_dbg("gpioG_func: 0x%02x\n", cfg.gpioA_function);
+	ft260_dbg("wakeup_int: 0x%02x\n", cfg.enable_wakeup_int);
 
 	switch (cfg.chip_mode) {
 	case FT260_MODE_ALL:
@@ -961,6 +1256,7 @@ static int ft260_probe(struct hid_device *hdev, const struct hid_device_id *id)
 {
 	struct ft260_device *dev;
 	struct ft260_get_chip_version_report version;
+	struct gpio_chip *chip;
 	int ret;
 
 	if (!hid_is_usb(hdev))
@@ -1036,6 +1332,37 @@ static int ft260_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		hid_err(hdev, "failed to create sysfs attrs\n");
 		goto err_i2c_free;
 	}
+
+	chip = gpiochip_find(FT260_GPIOCHIP, ft260_gpio_chip_match_name);
+	if (chip)
+		return 0;
+
+	hid_info(hdev, "initialize gpio chip\n");
+
+	dev->gpio_en = FT260_GPIO_DEFAULT;
+
+	dev->gc = devm_kzalloc(&hdev->dev, sizeof(*dev->gc), GFP_KERNEL);
+	if (!dev->gc) {
+		ret = -ENOMEM;
+		goto err_i2c_free;
+	}
+
+	hid_set_drvdata(hdev, dev);
+
+	dev->gc->label			= FT260_GPIOCHIP;
+	dev->gc->direction_input	= ft260_gpio_direction_input;
+	dev->gc->direction_output	= ft260_gpio_direction_output;
+	dev->gc->get_direction		= ft260_gpio_get_direction;
+	dev->gc->set			= ft260_gpio_set;
+	dev->gc->get			= ft260_gpio_get;
+	dev->gc->base			= -1;
+	dev->gc->ngpio			= FT260_GPIO_TOTAL;
+	dev->gc->can_sleep		= 1;
+	dev->gc->parent			= &hdev->dev;
+
+	ret = devm_gpiochip_add_data(&hdev->dev, dev->gc, dev);
+	if (ret)
+		goto err_i2c_free;
 
 	return 0;
 


### PR DESCRIPTION
This PR adds initial GPIO support.
I briefly tested it on the UMFT260EV1A board with old (sysfs) and new (chardev) GPIO user space interfaces.

```
michael@michael-VirtualBox:~/sw/hid-ft260$ ls /sys/class/gpio/
export  gpiochip1010  unexport
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo bash -c "echo 1015 > /sys/class/gpio/export"
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo bash -c "echo "out" > /sys/class/gpio/gpio1015/direction"
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo bash -c "cat /sys/class/gpio/gpio1015/value"
0
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo bash -c "echo 1 > /sys/class/gpio/gpio1015/value"
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo bash -c "cat /sys/class/gpio/gpio1015/value"
1
michael@michael-VirtualBox:~/sw/hid-ft260$ ls /dev/gpiochip*
/dev/gpiochip0

michael@michael-VirtualBox:~/sw/hid-ft260$ sudo gpiodetect
gpiochip0 [ft260_gpio] (14 lines)
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo gpioinfo 0
gpiochip0 - 14 lines:
	line   0:      unnamed       unused  output  active-high 
	line   1:      unnamed       unused  output  active-high 
	line   2:      unnamed       unused   input  active-high 
	line   3:      unnamed       unused  output  active-high 
	line   4:      unnamed       unused  output  active-high 
	line   5:      unnamed      "sysfs"  output  active-high [used]
	line   6:      unnamed       unused  output  active-high 
	line   7:      unnamed       unused  output  active-high 
	line   8:      unnamed       unused  output  active-high 
	line   9:      unnamed       unused  output  active-high 
	line  10:      unnamed       unused  output  active-high 
	line  11:      unnamed       unused  output  active-high 
	line  12:      unnamed       unused  output  active-high 
	line  13:      unnamed       unused  output  active-high 

michael@michael-VirtualBox:~/sw/hid-ft260$ sudo gpioget 0 5
gpioget: error reading GPIO values: Device or resource busy
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo gpioget 0 4
0
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo gpioset 0 4=1
michael@michael-VirtualBox:~/sw/hid-ft260$ sudo gpioget 0 4
1
```
 