### PR TITLE
Fix incorrectly inverted gpio direction

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -1090,7 +1090,7 @@ static int ft260_gpio_get_direction(struct gpio_chip *gc, u32 offset)
 	int ret = ft260_gpio_get_all(gc, FT260_GPIO_DIRECTION);
 	if (ret < 0)
 		return ret;
-	return (ret >> offset) & 1;
+	return ~((ret >> offset) & 1);
 }
 
 static int ft260_gpio_get(struct gpio_chip *gc, u32 offset)


### PR DESCRIPTION
The gpio_chip api callback get_direction expects 0 for OUT and 1 for IN, but the FT260 chip has this the other way around.
This causes the gpio directions in the sysfs to be incorrectly inverted.

That commit fixes the issue by inverting the value returned by the FT260