### PR TITLE
 HID: ft260: enable gpio based on i2c, uart and wakeup mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ KBUILD ?= /lib/modules/$(KRELEASE)/build
 obj-m += hid-ft260.o
 
 all:
-	$(MAKE) -C $(KBUILD) M=$(PWD) modules
+	$(MAKE) -C $(KBUILD) M=$(shell pwd) modules
 
 clean:
-	$(MAKE) -C $(KBUILD) M=$(PWD) clean
+	$(MAKE) -C $(KBUILD) M=$(shell pwd) clean

--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -1483,12 +1483,6 @@ static int ft260_i2c_probe(struct hid_device *hdev,
 		return -1;
 	}
 
-	ret = sysfs_create_group(&hdev->dev.kobj, &ft260_attr_group);
-	if (ret < 0) {
-		hid_err(hdev, "failed to create sysfs attrs\n");
-		goto err_i2c_free;
-	}
-
 	chip = gpiochip_find(hdev->phys, ft260_gpio_chip_match_name);
 	if (chip)
 		return 0;
@@ -1653,6 +1647,13 @@ static int ft260_probe(struct hid_device *hdev, const struct hid_device_id *id)
 	default:
 		goto err_hid_close;
 	}
+
+	ret = sysfs_create_group(&hdev->dev.kobj, &ft260_attr_group);
+	if (ret < 0) {
+		hid_err(hdev, "failed to create sysfs attrs\n");
+		goto err_hid_close;
+	}
+
 
 	return 0;
 

--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -1090,7 +1090,7 @@ static int ft260_gpio_get_direction(struct gpio_chip *gc, u32 offset)
 	int ret = ft260_gpio_get_all(gc, FT260_GPIO_DIRECTION);
 	if (ret < 0)
 		return ret;
-	return (ret >> offset) & 1;
+	return ~((ret >> offset) & 1);
 }
 
 static int ft260_gpio_get(struct gpio_chip *gc, u32 offset)

--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -987,8 +987,8 @@ static void ft260_gpio_set(struct gpio_chip *gc, u32 offset, int value)
 	mutex_lock(&dev->lock);
 
 	if (!(dev->gpio_en & (1 << offset))) {
-		hid_err(hdev, "%s: wrong pin function %d\n", __func__, offset);
-		goto exit;
+		hid_err(hdev, "%s: GPIO %d may not be configured as a GPIO. Continuing anyway.\n", __func__, offset);
+		// goto exit;
 	}
 
 	rep = (struct ft260_gpio_write_request_report *)&dev->feature_buf;
@@ -1044,9 +1044,9 @@ static int ft260_gpio_direction_set(struct gpio_chip *gc, u32 offset,
 	mutex_lock(&dev->lock);
 
 	if (!(dev->gpio_en & (1 << offset))) {
-		hid_err(hdev, "%s: wrong pin function %d\n", __func__, offset);
-		ret = -EIO;
-		goto exit;
+		hid_err(hdev, "%s: GPIO %d may not be configured as a GPIO. Continuing anyway.\n", __func__, offset);
+		// ret = -EIO;
+		// goto exit;
 	}
 
 	buf = (u8 *)&dev->feature_buf;

--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -1432,6 +1432,12 @@ static ssize_t i2c_reset_store(struct device *kdev,
 }
 static DEVICE_ATTR_WO(i2c_reset);
 
+static ssize_t hid_phys_show(struct device *dev, struct device_attribute *attr, char *buf) {
+    struct hid_device *hdev = to_hid_device(dev);
+    return scnprintf(buf, PAGE_SIZE, "%s\n", hdev->phys);
+}
+static DEVICE_ATTR_RO(hid_phys);
+
 static const struct attribute_group ft260_attr_group = {
 	.attrs = (struct attribute *[]) {
 		  &dev_attr_chip_mode.attr,
@@ -1449,6 +1455,7 @@ static const struct attribute_group ft260_attr_group = {
 		  &dev_attr_clock_ctl.attr,
 		  &dev_attr_i2c_reset.attr,
 		  &dev_attr_clock.attr,
+		  &dev_attr_hid_phys.attr,
 		  NULL
 	}
 };


### PR DESCRIPTION

 - enable gpio based on i2c, uart and wakeup mode
 - feat: Add enable_wake_int attribute
 - feat: replace dummy handler for uart_mode attribute
 - feat: replace dummy handler for i2c_enable attribute
 - feat: separate i2c and uart probing
 - feat: Add uio device for uart interface interupt
 - fix: allow several gpiochip for several ft260
 
 
 This is same as [PR12](https://github.com/MichaelZaidman/hid-ft260/pull/12)
 
 I've squashed all the commits, re-edit commit messages and pass the checkpatch script on it.
 Tested on a Beagle Bones Black (5.15.120-yocto armv7l) with 7 ft260
 Tested on a Raspberry Pi 4B (6.1.0 aarch64) with 1 ft260
 