### PR TITLE
Fix compile error on Linux <= 6.2.0 (timer_delete_sync renamed)

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -18,6 +18,8 @@
 #include <linux/kfifo.h>
 #include <linux/tty_flip.h>
 #include <linux/minmax.h>
+#include <linux/version.h>
+
 #include <asm/unaligned.h>
 
 #ifdef DEBUG
@@ -1127,8 +1129,11 @@ static void ft260_uart_port_put(struct ft260_device *port)
 
 static void ft260_uart_port_remove(struct ft260_device *port)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
 	timer_delete_sync(&port->wakeup_timer);
-
+#else
+	del_timer_sync(&port->wakeup_timer);
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
 	mutex_lock(&ft260_uart_list_lock);
 	list_del(&port->device_list);
 	mutex_unlock(&ft260_uart_list_lock);


### PR DESCRIPTION
I've had trouble compiling the module on current Debian Bookworm (kernel 6.1.0) due to renamed `timer_delete_sync` function (https://lore.kernel.org/lkml/166929936893.4906.6484824433900031971.tip-bot2@tip-bot2/). This patch allows the module to compile against kernels older than 6.2.0 which is when I believe the function was renamed.

Feedback welcome