### PR TITLE
Get rid of sysfs store big numbers failure notice

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -1430,6 +1430,7 @@ static void ft260_attr_dummy_func(struct hid_device *hdev, u8 req, u16 value)
 				hid_err(hdev, "%s: failed!\n", __func__);      \
 			else						       \
 				func(hdev, req, name);			       \
+			ret = count;					       \
 			mutex_unlock(&dev->lock);			       \
 		} else {						       \
 			ret = -EINVAL;					       \


### PR DESCRIPTION
When writing numbers higher than 999, get the following error:

$ sudo bash -c "echo 1000 > $sysfs_i2c_0/clock"
bash: line 1: echo: write error: Invalid argument

Despite this error notice, the clock gets the correct configuration.

$ sudo cat $sysfs_i2c_0/clock
1000

This commit gets rid of this notice.