### PR TITLE
hid-ft260: uart: enable flow control

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -1817,17 +1817,19 @@ static int ft260_uart_change_speed(struct ft260_device *port,
 
 	if (termios->c_cflag & CRTSCTS)
 		req.flow_ctrl = FT260_UART_CFG_FLOW_CTRL_RTS_CTS;
+
+        else if (termios->c_iflag & IXON || termios->c_iflag & IXOFF)
+		req.flow_ctrl = FT260_UART_CFG_FLOW_CTRL_XON_XOFF;
 	else
-		req.flow_ctrl = FT260_UART_CFG_FLOW_CTRL_OFF;
+		req.flow_ctrl = FT260_UART_CFG_FLOW_CTRL_NONE;
+
+	req.breaking = FT260_UART_CFG_BREAKING_NO;
 
 	ft260_dbg("configured termios: flow control: %d, baudrate: %d, ",
 		  req.flow_ctrl, baud);
 	ft260_dbg("data_bit: %d, parity: %d, stop_bit: %d, breaking: %d\n",
 		  req.data_bit, req.parity,
 		  req.stop_bit, req.breaking);
-
-	req.flow_ctrl = FT260_UART_CFG_FLOW_CTRL_NONE;
-	req.breaking = FT260_UART_CFG_BREAKING_NO;
 
 	mutex_lock(&port->lock);
 


### PR DESCRIPTION
The FT260 is a full-speed USB device. In USB, an Interrupt Transfer has a polling rate of 1 ms for full speed with a maximum packet size of 64 bytes. It translates to a payload data rate of 60 bytes per millisecond, 60 kilobytes per second, or 600000 bauds in an 8N1 configuration. It is the theoretical maximum for a full-speed USB Interrupt endpoint UART device.
According to the specs, the device supports UART speeds above 1M baud rates. It works well for relatively small data transfers. However, for large data transfers, the integrity of the data is not guaranteed at speeds exceeding 460800 baud.

This commit enables XON_XOFF and RTS_CTS UART flow control to reliably transfer data at higher than 460800 baud rates.

**Test 1: XON_XOFF: FT2232H (ttyUSB0) --> FT260 (ttyFT0)**
Terminal 1:
```
$ sudo stty -F /dev/ttyUSB0 1500000 cs8 -cstopb -parenb raw ixon ixoff -crtscts -echo
$ sudo stty -F /dev/ttyFT0 1500000 cs8 -cstopb -parenb raw ixon ixoff -crtscts -echo

michael@m2:~/sw/uart-test$ sudo dd if=pattern of=/dev/ttyUSB0 bs=1M 2+1 records in
2+1 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 48.1731 s, 60.0 kB/s

```
Terminal 2:
```
$ sudo dd if=/dev/ttyFT0 of=received.txt bs=1M
^C0+48104 records in
0+48104 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 58.5153 s, 49.4 kB/s
```

Compare sent and received files:
```
$ diff pattern received.txt
$
```

**Test 2: XON_XOFF: FT260 (ttyFT0) --> FT2232H (ttyUSB0)**
```
$ sudo dd if=pattern of=/dev/ttyFT0 bs=1M
2+1 records in
2+1 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 47.9895 s, 60.2 kB/s

```
```
$ sudo dd if=/dev/ttyUSB0 of=received.txt bs=1M
^C0+5667 records in
0+5667 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 54.7049 s, 52.8 kB/s
```

Compare sent and received files:
```
$ diff pattern received.txt
$
```

**Test 3: RTS_CTS: FT2232H (ttyUSB0) --> FT260 (ttyFT0)**
```
$ sudo stty -F /dev/ttyFT0 1500000 cs8 -cstopb -parenb raw -ixon -ixoff crtscts -echo
$ sudo stty -F /dev/ttyUSB0 1500000 cs8 -cstopb -parenb raw -ixon -ixoff crtscts -echo

$ sudo dd if=pattern of=/dev/ttyUSB0 bs=1M
2+1 records in
2+1 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 48.1545 s, 60.0 kB/s

```
```
$ sudo dd if=/dev/ttyFT0 of=received.txt bs=1M
^C0+48109 records in
0+48109 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 63.1389 s, 45.8 kB/s

```
Compare sent and received files:
```
$ diff pattern received.txt
$
```

**Test 4: RTS_CTS: FT260 (ttyFT0) --> FT2232H (ttyUSB0)**
```
$ sudo dd if=pattern of=/dev/ttyFT0 bs=1M
2+1 records in
2+1 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 48.1084 s, 60.1 kB/s
```

```
$ sudo dd if=/dev/ttyUSB0 of=received.txt bs=1M
^C0+5666 records in
0+5666 records out
2889405 bytes (2.9 MB, 2.8 MiB) copied, 56.492 s, 51.1 kB/s

```
Compare sent and received files:
```
$ diff pattern received.txt
$
```