### PR TITLE
27 implement ioctl calls tiocmbis tiocmbic tiocmget and tiocmset

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -1039,10 +1039,8 @@ static void ft260_gpio_en_update(struct hid_device *hdev, u8 req, u8 value)
 		default:
 			return;
 		}
-		hid_info(hdev, "enabled GPIOs: %04x, bitmap %04x\n", dev->gpio_en, bitmap);
 		ft260_gpio_en_clr(dev, bitmap);
 		bitmap = dev->gpio_uart_mode[value];
-		hid_info(hdev, "enabled GPIOs: %04x, bitmap %04x\n", dev->gpio_en, bitmap);
 		ft260_gpio_en_set(dev, bitmap);
 		goto exit;
 
@@ -1068,7 +1066,7 @@ static void ft260_gpio_en_update(struct hid_device *hdev, u8 req, u8 value)
 	else
 		ft260_gpio_en_clr(dev, bitmap);
 exit:
-	hid_info(hdev, "enabled GPIOs: %04x\n", dev->gpio_en);
+	hid_info(hdev, "enabled GPIOs: %04x, bitmap %04x\n", dev->gpio_en, bitmap);
 }
 
 static void ft260_gpio_output_cfg(struct ft260_gpio_state *gpio,
@@ -1269,8 +1267,6 @@ static int ft260_gpio_init(struct ft260_device *dev,
 	struct hid_device *hdev = dev->hdev;
 	char prefix[] = "ft260_";
 
-	hid_info(hdev, "initialize gpio chip\n");
-
 	dev->gpio_uart_mode[0] = (u16)FT260_GPIO_UART_MODE_0_SET;
 	dev->gpio_uart_mode[1] = (u16)FT260_GPIO_UART_MODE_1_SET;
 	dev->gpio_uart_mode[2] = (u16)FT260_GPIO_UART_MODE_2_SET;
@@ -1309,7 +1305,6 @@ static int ft260_gpio_init(struct ft260_device *dev,
 		goto exit;
 	}
 	snprintf(label, label_sz, "%s%s", prefix, dev_name(&hdev->dev));
-	hid_info(hdev, "initialize gpio chip on %s\n", label);
 
 	dev->gc->label			= label;
 	dev->gc->direction_input	= ft260_gpio_direction_input;
@@ -2160,8 +2155,6 @@ static int ft260_uart_port_activate(struct tty_port *tport, struct tty_struct *t
 	mod_timer(&port->wakeup_timer, jiffies +
 		  msecs_to_jiffies(FT260_WAKEUP_NEEDED_AFTER_MS));
 
-	hid_info(port->hdev, "enabled GPIOs: %04x\n", port->gpio_en);
-
 	return 0;
 }
 
@@ -2236,8 +2229,6 @@ static int ft260_i2c_probe(struct ft260_device *dev,
 		}
 	}
 
-	hid_info(hdev, "ft260_i2c_probe: enabled GPIOs: %04x\n", dev->gpio_en);
-
 	return 0;
 
 err_i2c_free:
@@ -2307,8 +2298,6 @@ static int ft260_uart_probe(struct ft260_device *dev,
 			goto err_hid_report;
 		}
 	}
-
-	hid_info(hdev, "ft260_uart_probe: enabled GPIOs: %04x\n", dev->gpio_en);
 
 	return 0;
 

--- a/setenv.sh
+++ b/setenv.sh
@@ -9,23 +9,36 @@
 # Usage:
 #   . ./setenv.sh
 
-# Example with 2 ft260 devices:
-#   michael@m2:~/sw/hid-ft260$ . setenv.sh
-#   sysfs_i2c_15
-#   sysfs_i2c_0
+# Example with 1 ft260 device:
+: '
+$ . setenv.sh
+sysfs_i2c_14
+sysfs_ttyFT0
 
-#   michael@m2:~/sw/hid-ft260$ echo $sysfs_i2c_0
-#   /sys/bus/hid/drivers/ft260/0003:0403:6030.0007
-#
-#   michael@m2:~/sw/hid-ft260$ echo $sysfs_i2c_15
-#   /sys/bus/hid/drivers/ft260/0003:0403:6030.000C
+$ echo $sysfs_i2c_14
+/sys/bus/hid/drivers/ft260/0003:0403:6030.0011
+'
+# Example with 2 ft260 devices:
+: '
+$ . setenv.sh
+sysfs_i2c_15
+sysfs_ttyFT1
+sysfs_i2c_14
+sysfs_ttyFT0
+
+$ echo $sysfs_i2c_15
+/sys/bus/hid/drivers/ft260/0003:0403:6030.0013
+'
 
 PVID='*0403:6030*'
 SYSFS_FT260=/sys/bus/hid/drivers/ft260/
 
-a=$(find $SYSFS_FT260 -name $PVID | xargs -I % sh -c 'find %/ -maxdepth 1 -name i2c-*')
-a+=" "
-a+=$(find $SYSFS_FT260 -name $PVID | xargs -I % sh -c 'find %/ -maxdepth 2 -name ttyFT*');
+a=$(find $SYSFS_FT260 -name $PVID | xargs -I % sh -c 'find %/ -maxdepth 1 -name i2c-* -o -name tty*')
 for w in $a; do
-	b=$(basename "$w"); c=$(dirname "$w"); d=sysfs_${b/-/_}; echo $d; declare $d=$c
+	b=$(basename "$w")
+	[ "$b" = "tty" ] && e=$(find $w/ -name ttyF*) && b=$(basename "$e")
+	c=$(dirname "$w")
+	d=sysfs_${b/-/_}
+	echo $d
+	declare $d=$c
 done


### PR DESCRIPTION
Added modem pins control via ioctl to enable programming an ESP32 over FT260 by esptool, which uses the TIOCMBIS, TIOCMBIC, TIOCMGET, and TIOCMSET ioctl calls to reset the chip via DTR and RTS pins.

The UART should be configured to SW or no flow control mode, like in the example below:
```
sudo stty -F /dev/ttyFT0 115200 raw -parity cs8 -cstopb -ixon -ixoff -crtscts
```