### PR TITLE
hid-ft260: add compatibility with Linux 6.12+

### DIFF
--- a/hid-ft260.c
+++ b/hid-ft260.c
@@ -19,7 +19,12 @@
 #include <linux/tty.h>
 #include <linux/tty_flip.h>
 #include <linux/minmax.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+#include <linux/unaligned.h>
+#else
 #include <asm/unaligned.h>
+#endif
 #include <linux/gpio/driver.h>
 
 #ifdef DEBUG


### PR DESCRIPTION
Since Linux 6.12, asm/unaligned.h was moved to linux/unaligned.h. Use a version guard to include the correct header based on the kernel version.